### PR TITLE
Use default announce list

### DIFF
--- a/lib/global.js
+++ b/lib/global.js
@@ -1,2 +1,1 @@
 global.WRTC = require('wrtc')
-global.WEBTORRENT_ANNOUNCE = [ 'wss://tracker.webtorrent.io' ]


### PR DESCRIPTION
`create-torrent` default announce list already contains `wss://tracker.webtorrent.io`, but also other non-web trackers.

By defining `global.WEBTORRENT_ANNOUNCE`, only the WebSocket tracker is announced to. To be really hybrid, shouldn't this client keep announcing to non-web trackers too?

For example:

```sh
# Before PR
webtorrent-hybrid seed somefile -q
# magnet:?xt=urn:btih:da035917573d54ed69b93bba3392e052ea34bb09&dn=somefile&tr=wss%3A%2F%2Ftracker.webtorrent.io

# After PR
webtorrent-hybrid seed somefile -q
# magnet:?xt=urn:btih:da035917573d54ed69b93bba3392e052ea34bb09&dn=somefile&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.publicbt.com%3A80&tr=udp%3A%2F%2Ftracker.webtorrent.io%3A80&tr=wss%3A%2F%2Ftracker.webtorrent.io

```