### PR TITLE
Headless electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In node.js, `webtorrent` no longer connects to WebRTC peers, just normal TCP/UDP
 
 While previous versions were using [wrtc](https://github.com/js-platform/node-webrtc), a WebRTC implementation via native extensions, for better compatibility the current one is based on [electron-webrtc](https://github.com/mappum/electron-webrtc). Its creating a hidden electron process which communicates with the Chromium API in the background. Since it comes with the overhead of [electron-prebuilt](https://github.com/electron-userland/electron-prebuilt) we are looking further  for a seamless integration through other implementations like [Node-RTCPeerConnection](https://github.com/nickdesaulniers/node-rtc-peer-connection).
 
-To run this package on a headless server follow [these instructions](https://github.com/mappum/electron-webrtc#running-on-a-headless-server).
+To run this package on a headless server execute [the provided script](bin/prepareHeadless.sh) or follow [these instructions](https://github.com/mappum/electron-webrtc#running-on-a-headless-server).
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 [![NPM Downloads][webtorrent-downloads-image]][webtorrent-downloads-url]
 
 
-### Streaming torrent client for node & the browser
+### Streaming torrent client for node environments
 
 In node.js, `webtorrent` no longer connects to WebRTC peers, just normal TCP/UDP peers. If you want to connect to all types of peers, including WebRTC peers, from node.js, you need to use this package (`webtorrent-hybrid`).
 
-The `wrtc` dependency (which provides WebRTC support in node.js) can be a bit difficult/slow to install and lacks Windows support, so we didn't want to burden all users of `webtorrent` with that process. If you just want to use WebTorrent in the browser, or in node.js to connect to normal TCP/UDP peers, then you can depend on [`webtorrent`](https://github.com/feross/webtorrent), which will be faster to install.
+While previous versions were using [wrtc](https://github.com/js-platform/node-webrtc), a WebRTC implementation via native extensions, for better compatibility the current one is based on [electron-webrtc](https://github.com/mappum/electron-webrtc). Its creating a hidden electron process which communicates with the Chromium API in the background. Since it comes with the overhead of [electron-prebuilt](https://github.com/electron-userland/electron-prebuilt) we are looking further  for a seamless integration through other implementations like [Node-RTCPeerConnection](https://github.com/nickdesaulniers/node-rtc-peer-connection).
+
+To run this package on a headless server follow [these instructions](https://github.com/mappum/electron-webrtc#running-on-a-headless-server).
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 

--- a/bin/prepareHeadless.sh
+++ b/bin/prepareHeadless.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Detect running X server, load Xvfb on headless systems and starts a virtual buffer
+
+if [ -z $(pidof X) ]; then
+
+  if [ ! $(which "Xvfb") ]; then
+    # TODO:
+    # - check alternative package support
+    sudo apt-get install xvfb
+  fi
+
+  running=$(pidof Xvfb)
+  if [ -z "$running" ]; then
+    kill running
+  fi
+
+  export DISPLAY="0:99"
+  Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+fi

--- a/examples/node-download.js
+++ b/examples/node-download.js
@@ -1,0 +1,24 @@
+// var WebTorrent = require('webtorrent-hybrid')
+var WebTorrent = require('../index')
+var fs = require('fs')
+
+var client = new WebTorrent()
+
+var torrentId = 'magnet:?xt=urn:btih:6a9759bffd5c0af65319979fb7832189f4f3c35d'
+
+console.log('torrentId:\t', torrentId)
+
+client.add(torrentId, function (torrent) {
+  var files = torrent.files
+  var length = files.length
+  // Stream each file to the disk
+  files.forEach(function (file) {
+    var source = file.createReadStream()
+    var destination = fs.createWriteStream(file.name)
+    source.on('end', function () {
+      console.log('file:\t\t', file.name)
+      // close after all files are saved
+      if (!--length) process.exit()
+    }).pipe(destination)
+  })
+})

--- a/examples/node-seed.js
+++ b/examples/node-seed.js
@@ -1,0 +1,13 @@
+// var WebTorrent = require('webtorrent-hybrid')
+var WebTorrent = require('../index')
+
+var client = new WebTorrent()
+
+var filePath = './node-seed.js'
+
+console.log('filePath:', filePath)
+
+client.seed(filePath, function (torrent) {
+  console.log('torrentId (info hash):', torrent.infoHash)
+  // console.log('torrentId (magnet link):', torrent.magnetURI)
+})

--- a/lib/global.js
+++ b/lib/global.js
@@ -1,5 +1,5 @@
 var createTorrent = require('create-torrent')
-var wrtc = require('wrtc')
+var wrtc = require('electron-webrtc')()
 
 global.WRTC = wrtc
 
@@ -10,5 +10,3 @@ global.WEBTORRENT_ANNOUNCE = createTorrent.announceList
   .filter(function (url) {
     return url.indexOf('wss://') === 0 || url.indexOf('ws://') === 0
   })
-
-console.log(global.WEBTORRENT_ANNOUNCE)

--- a/lib/global.js
+++ b/lib/global.js
@@ -1,3 +1,20 @@
 var wrtc = require('electron-webrtc')()
 
 global.WRTC = wrtc
+
+process.on('SIGINT', ensureCloseElectron)
+process.on('SIGTERM', ensureCloseElectron)
+
+var daemon = wrtc.electronDaemon
+
+daemon.on('error', function (err) {
+  if (err.message !== 'Daemon already closed') {
+    console.error(err)
+  }
+})
+
+function ensureCloseElectron(){
+  process.removeListener('SIGINT', ensureCloseElectron)
+  process.removeListener('SIGTERM', ensureCloseElectron)
+  daemon.close()
+}

--- a/lib/global.js
+++ b/lib/global.js
@@ -13,7 +13,7 @@ daemon.on('error', function (err) {
   }
 })
 
-function ensureCloseElectron(){
+function ensureCloseElectron () {
   process.removeListener('SIGINT', ensureCloseElectron)
   process.removeListener('SIGTERM', ensureCloseElectron)
   daemon.close()

--- a/lib/global.js
+++ b/lib/global.js
@@ -1,12 +1,3 @@
-var createTorrent = require('create-torrent')
 var wrtc = require('electron-webrtc')()
 
 global.WRTC = wrtc
-
-global.WEBTORRENT_ANNOUNCE = createTorrent.announceList
-  .map(function (arr) {
-    return arr[0]
-  })
-  .filter(function (url) {
-    return url.indexOf('wss://') === 0 || url.indexOf('ws://') === 0
-  })

--- a/lib/global.js
+++ b/lib/global.js
@@ -5,16 +5,14 @@ global.WRTC = wrtc
 process.on('SIGINT', ensureCloseElectron)
 process.on('SIGTERM', ensureCloseElectron)
 
-var daemon = wrtc.electronDaemon
-
-daemon.on('error', function (err) {
+wrtc.on('error', (err, source) => {
   if (err.message !== 'Daemon already closed') {
-    console.error(err)
+    console.error(err, source)
   }
 })
 
 function ensureCloseElectron () {
   process.removeListener('SIGINT', ensureCloseElectron)
   process.removeListener('SIGTERM', ensureCloseElectron)
-  daemon.close()
+  wrtc.close()
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/feross/webtorrent-hybrid/issues"
   },
   "dependencies": {
-    "create-torrent": "^3.23.1",
     "electron-webrtc": "0.0.3",
     "webtorrent": "^0.85.1",
     "webtorrent-cli": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "url": "https://github.com/feross/webtorrent-hybrid/issues"
   },
   "dependencies": {
-    "create-torrent": "^3.22.0",
-    "webtorrent": "0.x",
-    "webtorrent-cli": "1.x",
-    "wrtc": "0.0.x"
+    "create-torrent": "^3.23.1",
+    "electron-webrtc": "0.0.3",
+    "webtorrent": "^0.85.1",
+    "webtorrent-cli": "^1.0.1"
   },
   "devDependencies": {
-    "standard": "^6.0.4"
+    "standard": "^6.0.8"
   },
   "homepage": "http://webtorrent.io",
   "keywords": [
@@ -39,6 +39,7 @@
     "url": "git://github.com/feross/webtorrent-hybrid.git"
   },
   "scripts": {
+    "check": "npm outdated -depth 0",
     "test": "standard"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/feross/webtorrent-hybrid/issues"
   },
   "dependencies": {
-    "electron-webrtc": "0.0.3",
+    "electron-webrtc": "^0.1.0",
     "webtorrent": "^0.85.1",
     "webtorrent-cli": "^1.0.1"
   },


### PR DESCRIPTION
Using [electron-webrtc](https://github.com/mappum/electron-webrtc) as an alternative engine for [wrtc](https://github.com/js-platform/node-webrtc) (see #5).