### PR TITLE
Fixed README info about xvfb

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,40 +36,19 @@ On OS X, this should Just Work™.
 
 The current version of `webtorrent-hybrid` requires a screen, since the headless Electron
 instance expects one. If you're running in a screenless environment (like on a server),
-you must use a virtual screen such as `xvfb`. You must install it and run it before using
+you must use a virtual screen such as `xvfb`. You must install it before using
 `webtorrent-hybrid`.
 
 #### For Debian-based OSs:
 
 ```bash
 sudo apt-get install xvfb
-export DISPLAY='0:99'
-Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 ```
 
 #### For CentOS / RHEL:
 
 ```bash
 sudo yum install xorg-x11-server-Xvfb
-export DISPLAY='0:99'
-Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-```
-
-### Node.js API
-
-If you're using `webtorrent-hybrid` in a node.js project, you can start Xvfb within your
-app:
-
-```
-npm install xvfb
-```
-
-```js
-var Xvfb = require('xvfb')
-var xvfb = new Xvfb()
-xvfb.startSync()
-
-var WebTorrent = require('webtorrent-hybrid')
 ```
 
 ## Usage


### PR DESCRIPTION
The info about xvfb in the README was incorrect, the user doesn't need to start the Xvfb instance themselves since `electron-eval` does that itself while launching the Electron daemon. I think this makes the most sense because it improves UX and the `electron-eval` module should be responsible for all the setup for the Electron process.